### PR TITLE
Added Redirect folders to redirect for video links

### DIFF
--- a/redirects/SlopedTerrainBipedPolicies.html
+++ b/redirects/SlopedTerrainBipedPolicies.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
 <title>Redirecting...</title>
-<meta http-equiv="refresh" content="0; URL=https://youtu.be/CaG8HFQyWfo">
-<link rel="canonical" href="https://youtu.be/CaG8HFQyWfo">
+<meta http-equiv="refresh" content="0; URL=https://youtu.be/9r5EJg_Lzq0">
+<link rel="canonical" href="https://youtu.be/9r5EJg_Lzq0">

--- a/redirects/SlopedTerrainBipedPolicies.html
+++ b/redirects/SlopedTerrainBipedPolicies.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting...</title>
+<meta http-equiv="refresh" content="0; URL=https://youtu.be/CaG8HFQyWfo">
+<link rel="canonical" href="https://youtu.be/CaG8HFQyWfo">


### PR DESCRIPTION
This PR adds a './redirects/' folder to the parent directory such that we can have the flexibility to change video links even after submitting the paper or after it is published.
There is a sample file 'redirects/SlopedTerrainBipedPolicies.html' with a default youtube video link.
It can be demonstrated by going to
[https://stochlab.github.io/redirects/SlopedTerrainBipedPolicies.html](https://stochlab.github.io/redirects/SlopedTerrainBipedPolicies.html)
after merging.